### PR TITLE
Implement Post CRUD Operations and Tag-based Filtering

### DIFF
--- a/backend/demo-group7/pom.xml
+++ b/backend/demo-group7/pom.xml
@@ -61,6 +61,12 @@
 			<version>1.18.34</version>
 			<scope>provided</scope>
 		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-devtools</artifactId>
+		</dependency>
+
 	</dependencies>
 
 	<build>

--- a/backend/demo-group7/src/main/java/com/group7/demo/controllers/AuthenticationController.java
+++ b/backend/demo-group7/src/main/java/com/group7/demo/controllers/AuthenticationController.java
@@ -17,14 +17,10 @@ public class AuthenticationController {
     private final AuthenticationService authenticationService;
 
     @PostMapping("/register")
-    public ResponseEntity<String> register(@RequestBody RegisterRequest request) {
-        try {
-            User registeredUser = authenticationService.register(request);
-            // TODO: can create and return session token on signing up.
-            return ResponseEntity.status(HttpStatus.CREATED).body(null);
-        } catch (Exception e) {
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(e.getMessage());
-        }
+    public ResponseEntity<String> register(@RequestBody RegisterRequest request) throws Exception {
+        User registeredUser = authenticationService.register(request);
+        // TODO: can create and return session token on signing up.
+        return ResponseEntity.status(HttpStatus.CREATED).body(null);
     }
 
     @PostMapping("/login")

--- a/backend/demo-group7/src/main/java/com/group7/demo/controllers/PostController.java
+++ b/backend/demo-group7/src/main/java/com/group7/demo/controllers/PostController.java
@@ -1,0 +1,54 @@
+package com.group7.demo.controllers;
+
+import com.group7.demo.dtos.PostRequest;
+import com.group7.demo.dtos.PostResponse;
+import com.group7.demo.models.Post;
+import com.group7.demo.services.PostService;
+import lombok.AllArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.Set;
+
+@RestController
+@RequestMapping("/api/posts")
+@AllArgsConstructor
+public class PostController {
+    private PostService postService;
+
+    @PostMapping
+    public ResponseEntity<PostResponse> createPost(@RequestBody PostRequest postRequest) {
+        PostResponse createdPost = postService.createPost(postRequest);
+        return ResponseEntity.ok(createdPost);
+    }
+
+    @GetMapping
+    public ResponseEntity<List<PostResponse>> fetchPosts(
+            @RequestParam(required = false) Set<String> tags) {
+
+        List<PostResponse> posts;
+
+        if (tags != null) {
+            posts = postService.getPostsByTags(tags);
+            return ResponseEntity.ok(posts);
+        } else {
+            posts = postService.getAllPosts();
+        }
+
+        return ResponseEntity.ok(posts);
+    }
+
+    @DeleteMapping("/{postId}")
+    public ResponseEntity<String> deletePost(@PathVariable Long postId) {
+        postService.deletePost(postId);
+        return ResponseEntity.ok("Post deleted successfully.");
+    }
+
+//    @GetMapping("/by-tags")
+//    public ResponseEntity<List<PostResponse>> getPostsByTags(@RequestParam ) {
+//
+//    }
+}
+

--- a/backend/demo-group7/src/main/java/com/group7/demo/dtos/PostRequest.java
+++ b/backend/demo-group7/src/main/java/com/group7/demo/dtos/PostRequest.java
@@ -1,0 +1,16 @@
+package com.group7.demo.dtos;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.Set;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class PostRequest {
+
+    private String content;
+    private Set<String> tags;
+}

--- a/backend/demo-group7/src/main/java/com/group7/demo/dtos/PostResponse.java
+++ b/backend/demo-group7/src/main/java/com/group7/demo/dtos/PostResponse.java
@@ -1,0 +1,19 @@
+package com.group7.demo.dtos;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.Set;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class PostResponse {
+
+    private Long id;
+    private String content;
+    private Set<String> tags;
+    private LocalDateTime createdAt;
+}

--- a/backend/demo-group7/src/main/java/com/group7/demo/exceptions/ErrorResponse.java
+++ b/backend/demo-group7/src/main/java/com/group7/demo/exceptions/ErrorResponse.java
@@ -1,0 +1,41 @@
+package com.group7.demo.exceptions;
+
+import java.time.LocalDateTime;
+
+public class ErrorResponse {
+
+    private LocalDateTime timestamp;
+    private String message;
+    private String details;
+
+    public ErrorResponse(LocalDateTime timestamp, String message, String details) {
+        this.timestamp = timestamp;
+        this.message = message;
+        this.details = details;
+    }
+
+    // Getters and Setters
+    public LocalDateTime getTimestamp() {
+        return timestamp;
+    }
+
+    public void setTimestamp(LocalDateTime timestamp) {
+        this.timestamp = timestamp;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+    public String getDetails() {
+        return details;
+    }
+
+    public void setDetails(String details) {
+        this.details = details;
+    }
+}

--- a/backend/demo-group7/src/main/java/com/group7/demo/exceptions/handler/GlobalExceptionHandler.java
+++ b/backend/demo-group7/src/main/java/com/group7/demo/exceptions/handler/GlobalExceptionHandler.java
@@ -1,0 +1,50 @@
+package com.group7.demo.exceptions.handler;
+
+import com.group7.demo.exceptions.ErrorResponse;
+import jakarta.persistence.EntityNotFoundException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.context.request.WebRequest;
+
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.Map;
+
+@ControllerAdvice
+public class GlobalExceptionHandler {
+
+    // Handle generic exceptions
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> handleGlobalException(Exception ex, WebRequest request) {
+        ErrorResponse errorResponse = new ErrorResponse(
+                LocalDateTime.now(),
+                "An unexpected error occurred",
+                ex.getMessage()
+        );
+        return new ResponseEntity<>(errorResponse, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<Object> handleIllegalArgumentException(IllegalArgumentException ex, WebRequest request) {
+        Map<String, Object> body = new HashMap<>();
+        body.put("timestamp", LocalDateTime.now());
+        body.put("message", ex.getMessage());
+
+        return new ResponseEntity<>(body, HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(EntityNotFoundException.class)
+    public ResponseEntity<Object> handleEntityNotFoundException(EntityNotFoundException ex, WebRequest request) {
+        Map<String, Object> body = new HashMap<>();
+        body.put("timestamp", LocalDateTime.now());
+        body.put("message", ex.getMessage());
+
+        return new ResponseEntity<>(body, HttpStatus.NOT_FOUND);
+    }
+
+
+
+}

--- a/backend/demo-group7/src/main/java/com/group7/demo/models/Post.java
+++ b/backend/demo-group7/src/main/java/com/group7/demo/models/Post.java
@@ -1,0 +1,34 @@
+package com.group7.demo.models;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.util.HashSet;
+import java.util.Set;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@EqualsAndHashCode(exclude = "tags")  // Avoid using tags in equals and hashCode to prevent recursion
+public class Post {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String content;
+
+    private LocalDateTime createdAt;
+
+    @ManyToMany
+    @JoinTable(
+            name = "post_tags",
+            joinColumns = @JoinColumn(name = "post_id"),
+            inverseJoinColumns = @JoinColumn(name = "tag_name"))
+//    @JsonIgnoreProperties("posts")  // Prevents infinite recursion with Tag entity
+    private Set<Tag> tags = new HashSet<>();
+}

--- a/backend/demo-group7/src/main/java/com/group7/demo/models/Tag.java
+++ b/backend/demo-group7/src/main/java/com/group7/demo/models/Tag.java
@@ -1,0 +1,27 @@
+package com.group7.demo.models;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToMany;
+import lombok.*;
+
+import java.util.HashSet;
+import java.util.Set;
+
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@EqualsAndHashCode(exclude = "posts")  // Avoid using posts in equals and hashCode to prevent recursion
+public class Tag {
+
+    @Id
+    private String name;
+
+    @ManyToMany(mappedBy = "tags")
+//    @JsonIgnoreProperties("tags")  // Prevents infinite recursion with Post entity
+    private Set<Post> posts = new HashSet<>();
+}

--- a/backend/demo-group7/src/main/java/com/group7/demo/repository/PostRepository.java
+++ b/backend/demo-group7/src/main/java/com/group7/demo/repository/PostRepository.java
@@ -1,0 +1,22 @@
+package com.group7.demo.repository;
+
+import com.group7.demo.dtos.PostResponse;
+import com.group7.demo.models.Post;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Set;
+
+public interface PostRepository extends JpaRepository<Post, Long> {
+    List<Post> findByTags_Name(String tagName);
+
+    @Query("SELECT p.id, p.content, p.createdAt, t.name FROM Post p LEFT JOIN p.tags t")
+    List<Object[]> findAllPostDataWithTags();
+
+    @Query("SELECT DISTINCT p FROM Post p LEFT JOIN FETCH p.tags")
+    List<Post> findAllPostsWithTags();
+
+
+}

--- a/backend/demo-group7/src/main/java/com/group7/demo/repository/TagRepository.java
+++ b/backend/demo-group7/src/main/java/com/group7/demo/repository/TagRepository.java
@@ -1,0 +1,10 @@
+package com.group7.demo.repository;
+
+import com.group7.demo.models.Tag;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface TagRepository extends JpaRepository<Tag, Long> {
+    Optional<Tag> findByName(String name);
+}

--- a/backend/demo-group7/src/main/java/com/group7/demo/services/PostService.java
+++ b/backend/demo-group7/src/main/java/com/group7/demo/services/PostService.java
@@ -1,0 +1,109 @@
+package com.group7.demo.services;
+
+import com.group7.demo.dtos.PostRequest;
+import com.group7.demo.dtos.PostResponse;
+import com.group7.demo.models.Post;
+import com.group7.demo.models.Tag;
+import com.group7.demo.repository.PostRepository;
+import com.group7.demo.repository.TagRepository;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Service
+@AllArgsConstructor
+public class PostService {
+
+    private PostRepository postRepository;
+
+    private TagRepository tagRepository;
+
+    public PostResponse createPost(PostRequest postRequest) {
+        Set<Tag> tags = new HashSet<>();
+
+        for (String tagName : postRequest.getTags()) {
+            Tag tag = tagRepository.findByName(tagName)
+                    .orElseGet(() -> {
+                        // Create and save the new Tag
+                        Tag newTag = Tag.builder().name(tagName).build();
+                        return tagRepository.save(newTag);
+                    });
+            tags.add(tag);
+        }
+
+        Post post = Post.builder()
+                .content(postRequest.getContent())
+                .createdAt(LocalDateTime.now())
+                .tags(tags)
+                .build();
+
+        Post savedPost = postRepository.save(post);
+
+        return mapToPostResponse(savedPost);
+    }
+
+
+    public List<PostResponse> getAllPosts() {
+        List<Object[]> results = postRepository.findAllPostDataWithTags();
+
+        Map<Long, PostResponse> postResponseMap = new HashMap<>();
+
+        for (Object[] result : results) {
+            Long postId = (Long) result[0];
+            String content = (String) result[1];
+            LocalDateTime createdAt = (LocalDateTime) result[2];
+            String tagName = (String) result[3];
+
+            // Check if the PostResponse already exists for this post
+            PostResponse postResponse = postResponseMap.get(postId);
+
+            if (postResponse == null) {
+                // Create a new PostResponse if it doesn't exist
+                postResponse = new PostResponse(postId, content, new HashSet<>(), createdAt);
+                postResponseMap.put(postId, postResponse);
+            }
+
+            // Add the tag name to the PostResponse
+            postResponse.getTags().add(tagName);
+        }
+
+        // Return the list of PostResponse
+        return new ArrayList<>(postResponseMap.values());
+    }
+
+    public void deletePost(Long postId) {
+        // Check if the post exists
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new EntityNotFoundException("Post not found with id: " + postId));
+
+        // Delete the post
+        postRepository.delete(post);
+    }
+
+    public List<PostResponse> getPostsByTags(Set<String> tagNames) {
+        // Fetch all posts with tags
+        List<Post> posts = postRepository.findAllPostsWithTags();
+
+        // Filter posts that have at least one of the requested tags
+        return posts.stream()
+                .filter(post -> post.getTags().stream()
+                        .anyMatch(tag -> tagNames.contains(tag.getName())))
+                .map(this::mapToPostResponse)
+                .collect(Collectors.toList());
+    }
+
+    private PostResponse mapToPostResponse(Post post) {
+        return new PostResponse(
+                post.getId(),
+                post.getContent(),
+                post.getTags().stream().map(Tag::getName).collect(Collectors.toSet()),  // Only tag names
+                post.getCreatedAt()
+        );
+    }
+
+
+}

--- a/backend/demo-group7/src/main/resources/application.properties
+++ b/backend/demo-group7/src/main/resources/application.properties
@@ -7,7 +7,6 @@ spring.datasource.password=postgres
 # Hibernate dialect for PostgreSQL
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
 
-# Hibernate properties for DDL (Schema auto-update) - optional
 spring.jpa.hibernate.ddl-auto=update
 
 # Enable SQL query logging - optional


### PR DESCRIPTION
- **Post Creation**: Added `/api/posts` endpoint to allow the creation of new posts. It accepts a `PostRequest` DTO and returns a `PostResponse` containing the created post along with tag names.
- **Fetch Posts**: Implemented `fetchPosts()` to retrieve all posts. Added functionality to optionally filter posts by a number of tags, condition filter is any matching tag. No need to match for all tags in request parameter.
- **Delete Post**: Added `deletePost()` to allow the deletion of a post by its ID, returning a success message upon deletion.

### **Key Changes:**
- `createPost()`: Allows creation of posts with associated tags.
- `fetchPosts()`: Retrieves all posts, with future support for filtering by a tag(s).
- `deletePost()`: Enables deletion of posts by ID.
