### PR TITLE
Added lastCompletedWorkoutDate to TrainingProgramWithTrackingResponse

### DIFF
--- a/backend/demo-group7/src/main/java/com/group7/demo/dtos/TrainingProgramWithTrackingResponse.java
+++ b/backend/demo-group7/src/main/java/com/group7/demo/dtos/TrainingProgramWithTrackingResponse.java
@@ -7,6 +7,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Set;
@@ -28,6 +29,7 @@ public class TrainingProgramWithTrackingResponse {
     private TrainingProgramWithTrackingStatus status;
     private LocalDateTime joinedAt;
     private LocalDateTime completedAt;
+    private LocalDate lastCompletedWorkoutDate;
     private List<WeekWithTrackingResponse> weeks;
     private Set<String> participants;
 }

--- a/backend/demo-group7/src/main/java/com/group7/demo/dtos/mapper/Mapper.java
+++ b/backend/demo-group7/src/main/java/com/group7/demo/dtos/mapper/Mapper.java
@@ -8,6 +8,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
+import java.time.LocalDate;
 import java.util.Comparator;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -107,6 +108,7 @@ public class Mapper {
                 .joinedAt(trainingProgramWithTracking.getJoinedAt())
                 .status(trainingProgramWithTracking.getStatus())
                 .completedAt(trainingProgramWithTracking.getCompletedAt())
+                .lastCompletedWorkoutDate(getLastCompletedWorkoutDate(trainingProgramWithTracking))
                 .weeks(trainingProgramWithTracking.getWeeksWithTracking().stream()
                         .map(this::mapToWeekWithTrackingResponse)
                         .sorted(Comparator.comparing(WeekWithTrackingResponse::getWeekNumber))
@@ -155,6 +157,15 @@ public class Mapper {
                 .completedAt(workoutExerciseWithTracking.getCompletedAt())
                 .completedSets(workoutExerciseWithTracking.getCompletedSets())
                 .build();
+    }
+
+    private LocalDate getLastCompletedWorkoutDate(TrainingProgramWithTracking trainingProgramWithTracking) {
+        return trainingProgramWithTracking.getWeeksWithTracking().stream()
+                .flatMap(weekWithTracking -> weekWithTracking.getWorkoutsWithTracking().stream())
+                .filter(workoutWithTracking -> workoutWithTracking.getCompletedAt() != null)
+                .map(workoutWithTracking -> workoutWithTracking.getCompletedAt().toLocalDate())
+                .max(LocalDate::compareTo)
+                .orElse(null);
     }
 
 


### PR DESCRIPTION
Added "lastCompletedWorkoutDate" as described in [Issue#301](https://github.com/bounswe/bounswe2024group7/issues/301). If the user haven't completed any exercises this field will be `null`.