### PR TITLE
added Locale English to the uppercase function

### DIFF
--- a/backend/demo-group7/src/main/java/com/group7/demo/services/SurveyService.java
+++ b/backend/demo-group7/src/main/java/com/group7/demo/services/SurveyService.java
@@ -14,6 +14,7 @@ import jakarta.transaction.Transactional;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -48,7 +49,7 @@ public class SurveyService {
         Survey survey = Survey.builder()
                 .user(user)
                 .fitnessGoals(tags)
-                .fitnessLevel(ProgramLevel.valueOf(request.getFitnessLevel().toUpperCase())) // Convert to enum
+                .fitnessLevel(ProgramLevel.valueOf(request.getFitnessLevel().toUpperCase(Locale.ENGLISH)))
                 .build();
 
         Survey savedSurvey = surveyRepository.save(survey);


### PR DESCRIPTION
as explained in related issue, the toUppercase function doesnt take any language as parameter so it can convert the lowercase letter "i" into uppercase "İ" or "I" depending on the device. to make it consistent and get rid of errors depending on this, added Locale.ENGLISH 