### PR TITLE
removed redundant username field from Survey related requests

### DIFF
--- a/backend/demo-group7/src/main/java/com/group7/demo/dtos/SurveyRequest.java
+++ b/backend/demo-group7/src/main/java/com/group7/demo/dtos/SurveyRequest.java
@@ -7,7 +7,6 @@ import java.util.List;
 
 @Data
 public class SurveyRequest {
-    private String username; // Username of the user
     private List<String> fitnessGoals; // List of tag names
     private String fitnessLevel; // Beginner, Intermediate, Advanced
 }


### PR DESCRIPTION
In previous version, POST request to the endpoint: /api/surveys required this body:
{
    "username": "asim",
    "fitnessGoals": [
        "fitness",
        "arms"
    ],
    "fitnessLevel": "BEGINNER"
}

now the new body should remove username field:
{
    "fitnessGoals": [
        "fitness",
        "arms"
    ],
    "fitnessLevel": "BEGINNER"
}

also it should include user token as x-session-token in headers to take the user