### PR TITLE
288 seperate feed section to seperate pages fav list and explore

### DIFF
--- a/backend/demo-group7/src/main/java/com/group7/demo/controllers/PostController.java
+++ b/backend/demo-group7/src/main/java/com/group7/demo/controllers/PostController.java
@@ -10,6 +10,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 @RestController
@@ -98,10 +99,30 @@ public class PostController {
         return ResponseEntity.ok(bookmarkedPosts);
     }
 
-    @GetMapping("/fitness-goals")
-    public ResponseEntity<List<PostResponse>> fetchPostsByFitnessGoals(HttpServletRequest request) {
-        List<PostResponse> posts = postService.getPostsByFitnessGoals(request);
-        return ResponseEntity.ok(posts);
+    @GetMapping("/for-you")
+    public ResponseEntity<Map<String, Object>> fetchPostsByFitnessGoals(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size,
+            HttpServletRequest request) {
+        Map<String, Object> response = postService.getPostsByFitnessGoalsWithPagination(page, size, request);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/explore")
+    public ResponseEntity<Map<String, Object>> fetchPostsWithPagination(
+            @RequestParam(required = false) Set<String> tags,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size,
+            HttpServletRequest request) {
+
+        Map<String, Object> response;
+        if (tags != null) {
+            response = postService.getPostsByTagsWithPagination(tags, page, size, request);
+        } else {
+            response = postService.getAllPostsWithPagination(page, size, request);
+        }
+
+        return ResponseEntity.ok(response);
     }
 
 }

--- a/backend/demo-group7/src/main/java/com/group7/demo/repository/PostRepository.java
+++ b/backend/demo-group7/src/main/java/com/group7/demo/repository/PostRepository.java
@@ -3,6 +3,8 @@ package com.group7.demo.repository;
 import com.group7.demo.models.Post;
 import com.group7.demo.models.Tag;
 import com.group7.demo.models.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -29,5 +31,8 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     List<Post> search(@Param("query") String query);
 
     @Query("SELECT p FROM Post p JOIN p.tags t WHERE t IN :tags")
-    List<Post> findAllByTagsIn(@Param("tags") Set<Tag> tags);
+    Page<Post> findAllByTagsIn(@Param("tags") Set<Tag> tags, Pageable pageable);
+
+    @Query("SELECT DISTINCT p FROM Post p JOIN p.tags t WHERE t.name IN :tagNames")
+    Page<Post> findPostsByTagsWithPagination(@Param("tagNames") Set<String> tagNames, Pageable pageable);
 }


### PR DESCRIPTION
Implemented the new endpoints for feed page of user:

/api/posts/for-you?page=0&size=10 (default values for page and size values are given, no need for those queries)
/api/posts/explore?page=0&size=10 (default values for page and size values are given, no need for those queries)

Explanation:
for-you endpoint is for a registered users interests posts. in survey, user chooses some tags for fitnessGoals. After user chooses these tags, for-you page shows all the posts with those tags to the user. the endpoints example response is like:
{
    "totalItems": 54,
    "totalPages": 6,
    "currentPage": 0,
    "posts": [
        {
            "id": 1,
            "content": "post content",
            "tags": [
                "tag1",
                "tag2",
                "tag3"
            ],
            "createdAt": "2024-12-15T18:45:15.536824",
            "username": "asim",
            "trainingProgram": null,
            "likeCount": 0,
            "imageUrl": null,
            "liked": false,
            "bookmarked": false
        },
        ......
        
    ]
}

it returns given sized post list.
for for-you endpoint, the request should include x-session-token