### PR TITLE
Implemented order by likes in descending order

### DIFF
--- a/backend/demo-group7/src/main/java/com/group7/demo/repository/PostRepository.java
+++ b/backend/demo-group7/src/main/java/com/group7/demo/repository/PostRepository.java
@@ -35,4 +35,13 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 
     @Query("SELECT DISTINCT p FROM Post p JOIN p.tags t WHERE t.name IN :tagNames")
     Page<Post> findPostsByTagsWithPagination(@Param("tagNames") Set<String> tagNames, Pageable pageable);
+
+    @Query("SELECT p FROM Post p LEFT JOIN p.tags t WHERE t IN :tags ORDER BY SIZE(p.likedByUsers) DESC")
+    Page<Post> findAllByTagsInOrderByLikesDesc(@Param("tags") Set<Tag> tags, Pageable pageable);
+
+    @Query("SELECT DISTINCT p FROM Post p LEFT JOIN p.tags t WHERE t.name IN :tagNames ORDER BY SIZE(p.likedByUsers) DESC")
+    Page<Post> findPostsByTagsWithPaginationOrderByLikesDesc(@Param("tagNames") Set<String> tagNames, Pageable pageable);
+
+    @Query("SELECT p FROM Post p ORDER BY SIZE(p.likedByUsers) DESC")
+    Page<Post> findAllOrderByLikesDesc(Pageable pageable);
 }

--- a/backend/demo-group7/src/main/java/com/group7/demo/services/PostService.java
+++ b/backend/demo-group7/src/main/java/com/group7/demo/services/PostService.java
@@ -212,9 +212,9 @@ public class PostService {
 
         // Create Pageable object
         Pageable paging = PageRequest.of(page, size);
-
-        // Fetch posts with pagination
-        Page<Post> pagePost = postRepository.findAllByTagsIn(fitnessGoals, paging);
+        
+        // Use the new method that sorts by likes
+        Page<Post> pagePost = postRepository.findAllByTagsInOrderByLikesDesc(fitnessGoals, paging);
 
         // Get content for current page
         List<PostResponse> posts = pagePost.getContent().stream()
@@ -233,7 +233,9 @@ public class PostService {
     @Transactional
     public Map<String, Object> getAllPostsWithPagination(int page, int size, HttpServletRequest request) {
         Pageable paging = PageRequest.of(page, size);
-        Page<Post> pagePost = postRepository.findAll(paging);
+        
+        // Use the new method that sorts by likes
+        Page<Post> pagePost = postRepository.findAllOrderByLikesDesc(paging);
 
         List<PostResponse> posts = pagePost.getContent().stream()
                 .map(post -> mapper.mapToPostResponse(post, request))
@@ -251,7 +253,9 @@ public class PostService {
     @Transactional
     public Map<String, Object> getPostsByTagsWithPagination(Set<String> tagNames, int page, int size, HttpServletRequest request) {
         Pageable paging = PageRequest.of(page, size);
-        Page<Post> pagePost = postRepository.findPostsByTagsWithPagination(tagNames, paging);
+        
+        // Use the new method that sorts by likes
+        Page<Post> pagePost = postRepository.findPostsByTagsWithPaginationOrderByLikesDesc(tagNames, paging);
 
         List<PostResponse> posts = pagePost.getContent().stream()
                 .map(post -> mapper.mapToPostResponse(post, request))


### PR DESCRIPTION
As requested, Implemented ordering for pages of posts in /for-you and /explore endpoints.
