### PR TITLE
implemented recommendation to trainingPrograms

### DIFF
--- a/backend/demo-group7/src/main/java/com/group7/demo/controllers/TrainingProgramController.java
+++ b/backend/demo-group7/src/main/java/com/group7/demo/controllers/TrainingProgramController.java
@@ -116,6 +116,21 @@ public class TrainingProgramController {
         return ResponseEntity.ok().build();
     }
 
+    @GetMapping("/recommended")
+    public ResponseEntity<Map<String, Object>> getRecommendedPrograms(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size,
+            HttpServletRequest request) {
+        Map<String, Object> response = trainingProgramService.getRecommendedPrograms(page, size, request);
+        return ResponseEntity.ok(response);
+    }
 
+    @GetMapping("/explore")
+    public ResponseEntity<Map<String, Object>> explorePrograms(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size) {
+        Map<String, Object> response = trainingProgramService.explorePrograms(page, size);
+        return ResponseEntity.ok(response);
+    }
 
 }

--- a/backend/demo-group7/src/main/java/com/group7/demo/repository/TrainingProgramRepository.java
+++ b/backend/demo-group7/src/main/java/com/group7/demo/repository/TrainingProgramRepository.java
@@ -2,6 +2,9 @@ package com.group7.demo.repository;
 
 import com.group7.demo.models.TrainingProgram;
 import com.group7.demo.models.User;
+import com.group7.demo.models.enums.ProgramLevel;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -16,4 +19,13 @@ public interface TrainingProgramRepository extends JpaRepository<TrainingProgram
             "LOWER(t.title) LIKE LOWER(CONCAT('%', :query, '%')) OR " +
             "LOWER(t.description) LIKE LOWER(CONCAT('%', :query, '%'))")
     List<TrainingProgram> search(@Param("query") String query);
+
+    @Query("SELECT t FROM TrainingProgram t " +
+           "WHERE t.level = :fitnessLevel " +
+           "ORDER BY SIZE(t.participants) DESC, t.rating DESC")
+    Page<TrainingProgram> findRecommendedPrograms(
+            @Param("fitnessLevel") ProgramLevel fitnessLevel,
+            Pageable pageable);
+
+    Page<TrainingProgram> findAllByOrderByParticipantsDesc(Pageable pageable);
 }


### PR DESCRIPTION
In feed page, now we can show training programs in two category:
recommended:
in endpoint api/training-programs/recommended I implemented recommended programs by using registered users fitness level. now the recommended programs are shown in pages with same level as user.
in endpoint api/training-programs/explore I implemented all programs with pages ordered by users joined to that program.

IMPORTANT!
recommended endpoint requires user session token since it shows personalized programs
explore endpoint is public 